### PR TITLE
Add MySQL connection test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "db:test": "node scripts/dbTest.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/dbTest.js
+++ b/scripts/dbTest.js
@@ -1,0 +1,20 @@
+import mysql from 'mysql2/promise';
+
+async function main() {
+  try {
+    const connection = await mysql.createConnection({
+      host: process.env.DB_HOST || 'mysql.hostinger.com',
+      user: process.env.DB_USER || 'u327759188_srbijaikosovo',
+      password: process.env.DB_PASSWORD || 'Lepamojaglava12!',
+      database: process.env.DB_NAME || 'u327759188_srbijaikosovo',
+    });
+
+    const [rows] = await connection.query('SELECT NOW() AS now');
+    console.log('Connected to MySQL, current time:', rows[0].now);
+    await connection.end();
+  } catch (err) {
+    console.error('Failed to connect to MySQL:', err.message);
+  }
+}
+
+main();

--- a/src/components/sections/Categories.tsx
+++ b/src/components/sections/Categories.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Code, Palette, PenTool, TrendingUp, Video, Settings, BarChart, Shield } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 
-const iconMap: Record<string, any> = {
+const iconMap: Record<string, ComponentType> = {
   Code,
   Palette,
   PenTool,

--- a/src/components/sections/ProjectSlider.tsx
+++ b/src/components/sections/ProjectSlider.tsx
@@ -86,7 +86,11 @@ const ProjectSlider = () => {
     return date.toLocaleDateString("hr-HR");
   };
 
-  const getClientName = (profile: any) => {
+  const getClientName = (profile: {
+    company_name?: string;
+    first_name?: string;
+    last_name?: string;
+  }) => {
     if (profile.company_name) return profile.company_name;
     if (profile.first_name && profile.last_name) {
       return `${profile.first_name} ${profile.last_name}`;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -120,5 +121,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a MySQL connection test script that uses provided credentials
- expose an npm script `db:test` to run the test
- fix several lint errors in components and Tailwind config

## Testing
- `node scripts/dbTest.js` (fails: Cannot find package 'mysql2')
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab482f65d08324b087b524621e046d